### PR TITLE
Update branch hour tests, support Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-beautifulsoup4==4.12.2
-requests==2.31.0
-lxml==4.9.0
+beautifulsoup4~=4.13.4
+requests~=2.31.0
+lxml~=5.4.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,16 +104,9 @@ class TestScraper(unittest.TestCase):
         'test branch hours'
         branch = sfpl.Branch('west portal')
         actual_hours = branch.getHours()
-        expected_hours = {
-            'Sun': '1 - 5',
-            'Mon': '1 - 6',
-            'Tue': '10 - 8',
-            'Wed': '10 - 8',
-            'Thu': '10 - 8',
-            'Fri': '1 - 6',
-            'Sat': '10 - 6',
-        }
-        self.assertEqual(actual_hours, expected_hours)
+        for day in ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']:
+            self.assertIn(day, actual_hours)
+            self.assertRegex(actual_hours[day], r'\d+ - \d+')
 
     def test_branch_hours_all(self):
         'test branch hours on all branches approximately'


### PR DESCRIPTION
# Changes

1. Updates the branch-hours unit test: rather than storing expected hours (subject to change), check for each day's membership in the map and compare values to a regex (`\d+ - \d+`).
2. Update dependencies and loosen them (allow different but compatible versions). `lxml` introduced Python 3.13 support in v5.0.0 ([changelog](https://lxml.de/5.1/changes-5.1.0.html)).

# Motivation

This is precursor work to some other improvements I'd like to contribute to this project; with this PR, you can install `sfpl` and run the tests on a recent version of Python.

It seems the SFPL DOM for some of these API interfaces has changed — e.g. checkouts and holds are extractable from a JSON block, not from XML. Expect those updates in future PRs; see my working branch: https://github.com/lukasschwab/sfpl/pull/1

# Testing

Unit tests pass.

```console
$ pytest tests
===================================================== test session starts ======================================================
platform darwin -- Python 3.10.4, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/lukas/Programming/SFPL
plugins: anyio-3.7.1
collected 18 items

tests/test_api.py ..................                                                                                     [100%]

======================================================= warnings summary =======================================================
sfpl/sfpl.py:15
  /Users/lukas/Programming/SFPL/sfpl/sfpl.py:15: DeprecationWarning: invalid escape sequence '\d'
    id_regex = 'https://sfpl.bibliocommons.com/.+/(\d+)'

sfpl/sfpl.py:16
  /Users/lukas/Programming/SFPL/sfpl/sfpl.py:16: DeprecationWarning: invalid escape sequence '\d'
    book_page_regex = '[\d,]+ to [\d,]+ of ([\d,]+) results?'

sfpl/sfpl.py:17
  /Users/lukas/Programming/SFPL/sfpl/sfpl.py:17: DeprecationWarning: invalid escape sequence '\d'
    list_page_regex = '[\d,]+ - [\d,]+ of ([\d,]+) items?'

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 18 passed, 3 warnings in 45.39s ================================================
```